### PR TITLE
Corrección: Se utiliza variable de entorno de la API_URL

### DIFF
--- a/webapp/src/pages/Register.tsx
+++ b/webapp/src/pages/Register.tsx
@@ -19,7 +19,8 @@ const Register: React.FC = () => {
     }
 
     try {
-      const response = await fetch('http://localhost:3000/createuser', {
+      const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3000'
+      const response = await fetch(`${API_URL}/createuser`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password, confirmPassword }),


### PR DESCRIPTION
Arreglo en la llamada al servicio de registro para usar la variable de entorno.