### PR TITLE
Modificada la puntuación máxima según la dificultad

### DIFF
--- a/webapp/src/__tests__/Game.test.tsx
+++ b/webapp/src/__tests__/Game.test.tsx
@@ -10,13 +10,17 @@ import * as userService from '../services/userService'
 
 // Mock de useNavigate
 const mockNavigate = vi.fn()
+const mockLocationState: { size: number; botId: string; difficulty?: string } = {
+    size: 11,
+    botId: 'random_bot',
+}
 
 vi.mock('react-router-dom', async() => {
     const actual = await vi.importActual('react-router-dom')
     return {
         ...actual,
         useLocation: () => ({
-            state: { size: 11, botId: 'random_bot'},
+            state: mockLocationState,
         }),
         useNavigate: () => mockNavigate,
     }
@@ -42,6 +46,11 @@ vi.mock('../config/botsConfig', () => ({
         shortest_path_bot: 'Dijkstra',
     },
     getTimeLimitForBot: vi.fn(() => 30),
+    getDifficultyForBot: vi.fn((botId: string) => {
+        if (botId === 'random_bot') return 'facil'
+        if (botId === 'heuristic_bot' || botId === 'defensive_bot') return 'media'
+        return 'dificil'
+    }),
 }))
 
 vi.mock('../pages/gui/GameBoard', () => ({
@@ -64,6 +73,9 @@ vi.mock('../pages/DialogResult', () => ({
 
 describe('Game Component', () => {
     beforeEach(() => {
+        mockLocationState.size = 11
+        mockLocationState.botId = 'random_bot'
+        delete mockLocationState.difficulty
         localStorage.setItem('user', JSON.stringify({username:'test1'}))
         localStorage.setItem('token', 'dummy-token')
         HTMLDialogElement.prototype.showModal = vi.fn()
@@ -140,7 +152,7 @@ describe('Game Component', () => {
             expect(gameService.updateUserStats).toHaveBeenCalledWith(
                 'test1',
                 true,
-                10000
+                4000
             )
         })
     })
@@ -173,9 +185,27 @@ describe('Game Component', () => {
         expect(screen.getByText('Invitado')).toBeInTheDocument()
     })
 
-    test('muestra la puntuación inicial de 10000', async () => {
+    test('muestra la puntuación inicial de 4000 para dificultad fácil', async () => {
+        await renderComponent()
+        expect(screen.getByText(/Puntuación: 4000/)).toBeInTheDocument()
+    })
+
+    test('usa 6000 cuando llega dificultad media', async () => {
+        mockLocationState.difficulty = 'media'
+        await renderComponent()
+        expect(screen.getByText(/Puntuación: 6000/)).toBeInTheDocument()
+    })
+
+    test('usa 10000 cuando llega dificultad difícil', async () => {
+        mockLocationState.difficulty = 'dificil'
         await renderComponent()
         expect(screen.getByText(/Puntuación: 10000/)).toBeInTheDocument()
+    })
+
+    test('usa dificultad del bot si no llega dificultad', async () => {
+        mockLocationState.botId = 'heuristic_bot'
+        await renderComponent()
+        expect(screen.getByText(/Puntuación: 6000/)).toBeInTheDocument()
     })
 
     test('muestra el contador de movimientos inicial en 0', async () => {

--- a/webapp/src/pages/Game.tsx
+++ b/webapp/src/pages/Game.tsx
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { updateUserStats } from '../services/gameService';
 import { getUserScore } from '../services/gameService';
-import { BOTS, getTimeLimitForBot } from '../config/botsConfig';
+import { BOTS, getTimeLimitForBot, getDifficultyForBot } from '../config/botsConfig';
 import './Game.css';
 import DialogResult from './DialogResult';
 import {useNavigate} from 'react-router-dom';
@@ -17,11 +17,18 @@ function Game() {
   const navigate = useNavigate();
   const location = useLocation();
   const { user } = useAuth();
-  const { size, botId } = location.state || { size: 12, botId: "heuristic_bot" };
+  const { size, botId, difficulty } = location.state || { size: 12, botId: "heuristic_bot", difficulty: undefined };
+  const selectedDifficulty = difficulty ?? getDifficultyForBot(botId);
+  const INITIAL_SCORE_BY_DIFFICULTY: Record<string, number> = {
+    facil: 4000,
+    media: 6000,
+    dificil: 10000,
+  };
+  const initialScore = INITIAL_SCORE_BY_DIFFICULTY[selectedDifficulty] ?? 6000;
   // useRef es un hook que sirve para mantener referencia a un componente y poder llamar a sus métodos.
   const gameBoardRef = useRef<GameBoardHandle>(null);
 
-  const [playerScore, setPlayerScore] = useState(10000);
+  const [playerScore, setPlayerScore] = useState(initialScore);
   const [gameOver, setGameOver] = useState(false);
   const [dialogContent, setDialogContent] = useState<React.ReactNode>(null);
   const [moveCount, setMoveCount] = useState(0);


### PR DESCRIPTION
This pull request updates the scoring logic in the game to make the initial score depend on the selected difficulty level, rather than always starting at 10,000. It also adds tests to verify the correct score is set for each difficulty, and updates mocks and test setup accordingly.

**Game scoring logic improvements:**

* The initial player score in `Game.tsx` is now determined by the selected difficulty, defaulting to the bot's difficulty if none is provided. Scores are set to 4,000 for "facil" (easy), 6,000 for "media" (medium), and 10,000 for "dificil" (hard), with a default of 6,000 if the difficulty is unrecognized. (`webapp/src/pages/Game.tsx`) [[1]](diffhunk://#diff-b8dbde48fee88cb44183e1818346466bf0c1267a667fd5ada27338db9d217fb4L8-R8) [[2]](diffhunk://#diff-b8dbde48fee88cb44183e1818346466bf0c1267a667fd5ada27338db9d217fb4L20-R31)

**Test enhancements and fixes:**

* Added and updated tests in `Game.test.tsx` to verify that the initial score is set correctly for each difficulty level, including cases where the difficulty comes from the bot configuration. (`webapp/src/__tests__/Game.test.tsx`) [[1]](diffhunk://#diff-418cdd7edded1b7a93499cbaf1acbdda663a52afb4dab7f0d792e3bc70eb0e89L143-R155) [[2]](diffhunk://#diff-418cdd7edded1b7a93499cbaf1acbdda663a52afb4dab7f0d792e3bc70eb0e89L176-R210)
* Updated the test mock for `botsConfig` to provide a `getDifficultyForBot` function, returning the appropriate difficulty string for each bot. (`webapp/src/__tests__/Game.test.tsx`)
* Refactored the test setup to use a shared `mockLocationState` object, ensuring tests can easily set the desired state for each scenario. (`webapp/src/__tests__/Game.test.tsx`) [[1]](diffhunk://#diff-418cdd7edded1b7a93499cbaf1acbdda663a52afb4dab7f0d792e3bc70eb0e89R13-R23) [[2]](diffhunk://#diff-418cdd7edded1b7a93499cbaf1acbdda663a52afb4dab7f0d792e3bc70eb0e89R76-R78)

Closes #139 