### PR TITLE
Modificada la ventana de ayuda para que ayude de verdad

### DIFF
--- a/webapp/src/__tests__/HelpDialog.test.tsx
+++ b/webapp/src/__tests__/HelpDialog.test.tsx
@@ -26,33 +26,90 @@ describe ('HelpContent', () => {
     })
 
     describe('Apartados de contenido', () => {
-        test('muestra el apartado Objetivo', () => {
+        test('muestra el apartado Objetivo del Juego', () => {
             render(<HelpContent />)
-            expect(screen.getByText('Objetivo')).toBeInTheDocument()
+            expect(screen.getByText('Objetivo del Juego')).toBeInTheDocument()
         })
 
-        test('muestra el apartado Reglas.', () => {
+        test('muestra el apartado El Tablero', () => {
             render(<HelpContent />)
-            expect(screen.getByText('Reglas')).toBeInTheDocument()
+            expect(screen.getByText('El Tablero')).toBeInTheDocument()
+        })
+
+        test('muestra el apartado Reglas del Juego', () => {
+            render(<HelpContent />)
+            expect(screen.getByText('Reglas del Juego')).toBeInTheDocument()
+        })
+
+        test('muestra el apartado Cómo Ganar o Perder', () => {
+            render(<HelpContent />)
+            expect(screen.getByText('Cómo Ganar o Perder')).toBeInTheDocument()
         })
     })
 
     describe('Reglas del juego', () => {
-        test('muestra la regla de los turnos.', () =>{
+        test('muestra exactamente 6 reglas', () =>{
             render(<HelpContent />)
-            expect(screen.getByText('Los jugadores se turnan colocando una ficha por turno.')).toBeInTheDocument()
+            expect(screen.getAllByRole('listitem')).toHaveLength(6)
         })
-        test('muestra la regla de casillas vacías.', () =>{
+
+        test('muestra la regla de los turnos', () =>{
             render(<HelpContent />)
-            expect(screen.getByText('Sólo puedes colocar fichas en casillas vacías.')).toBeInTheDocument()
+            expect(screen.getByText(/Los jugadores alternan turnos/)).toBeInTheDocument()
         })
-        test('muestra la regla de la victoria', () =>{
+
+        test('muestra la regla de colocación', () =>{
             render(<HelpContent />)
-            expect(screen.getByText('El primero en conectar sus dos lados gana la partida.')).toBeInTheDocument()
+            expect(screen.getByText(/En tu turno, haz clic en una casilla vacía/)).toBeInTheDocument()
         })
-        test('muestra exactamente 3 reglas', () =>{
+
+        test('muestra la regla de una ficha por turno', () =>{
             render(<HelpContent />)
-            expect(screen.getAllByRole('listitem')).toHaveLength(3)
+            expect(screen.getByText(/Solo puedes colocar una ficha por turno/)).toBeInTheDocument()
+        })
+
+        test('muestra la regla de casillas ocupadas', () =>{
+            render(<HelpContent />)
+            expect(screen.getByText(/No puedes colocar fichas donde ya hay fichas/)).toBeInTheDocument()
+        })
+
+        test('muestra la regla del tiempo limitado por turno', () =>{
+            render(<HelpContent />)
+            expect(screen.getByText(/Tienes un tiempo limitado para colocar tu ficha en cada ronda/)).toBeInTheDocument()
+        })
+
+        test('muestra la regla de fichas adyacentes', () =>{
+            render(<HelpContent />)
+            expect(screen.getByText(/Tus fichas deben estar conectadas entre sí/)).toBeInTheDocument()
+        })
+    })
+
+    describe('Objetivo y condiciones de victoria', () => {
+        test('menciona conectar los tres lados del tablero', () => {
+            render(<HelpContent />)
+            expect(screen.getByText(/toque los tres lados del tablero triangular/)).toBeInTheDocument()
+        })
+
+        test('muestra la condición de victoria', () => {
+            render(<HelpContent />)
+            expect(screen.getByText(/si consigues formar una línea continua de fichas azules/)).toBeInTheDocument()
+        })
+
+        test('muestra la condición de derrota', () => {
+            render(<HelpContent />)
+            expect(screen.getByText(/si el bot completa su línea ganadora primero/)).toBeInTheDocument()
+        })
+    }) 
+
+    describe('Información del tablero', () => {
+        test('describe el tablero como triangular', () => {
+            render(<HelpContent />)
+            expect(screen.getByText(/El tablero es triangular/)).toBeInTheDocument()
+        })
+
+        test('menciona las casillas hexagonales', () => {
+            render(<HelpContent />)
+            expect(screen.getByText(/dividido en casillas hexagonales/)).toBeInTheDocument()
         })
     })
 })
@@ -81,21 +138,24 @@ describe('HelpDialog', () => {
             expect(screen.getByText('¿Cómo jugar?')).toBeInTheDocument()
         })
 
-        test('muestra el apartado Objetivo', () => {
+        test('muestra el apartado Objetivo del Juego', () => {
             render(<HelpDialog open={true} onClose={vi.fn()} />)
-            expect(screen.getByText('Objetivo')).toBeInTheDocument()
+            expect(screen.getByText('Objetivo del Juego')).toBeInTheDocument()
         })
 
-        test('muestra el apartado Reglas', () => {
+        test('muestra el apartado El Tablero', () => {
             render(<HelpDialog open={true} onClose={vi.fn()} />)
-            expect(screen.getByText('Reglas')).toBeInTheDocument()
+            expect(screen.getByText('El Tablero')).toBeInTheDocument()
         })
 
-        test('muestra las tres reglas del juego', () => {
+        test('muestra el apartado Reglas del Juego', () => {
             render(<HelpDialog open={true} onClose={vi.fn()} />)
-            expect(screen.getByText('Los jugadores se turnan colocando una ficha por turno.')).toBeInTheDocument()
-            expect(screen.getByText('Sólo puedes colocar fichas en casillas vacías.')).toBeInTheDocument()
-            expect(screen.getByText('El primero en conectar sus dos lados gana la partida.')).toBeInTheDocument()
+            expect(screen.getByText('Reglas del Juego')).toBeInTheDocument()
+        })
+
+        test('muestra el apartado Cómo Ganar o Perder', () => {
+            render(<HelpDialog open={true} onClose={vi.fn()} />)
+            expect(screen.getByText('Cómo Ganar o Perder')).toBeInTheDocument()
         })
 
         test('muestra el botón de cierre', () => {

--- a/webapp/src/pages/HelpContent.tsx
+++ b/webapp/src/pages/HelpContent.tsx
@@ -3,22 +3,43 @@ const HelpContent = () => {
         <div className="help-content">
             <h2>¿Cómo jugar?</h2>
             <p>
-                YoVi es un juego de estrategia por turnos en un tablero triangular.
-                Tú juegas con las fichas azules y el bot con las fichas rojas.
+                YoVi es un juego de estrategia por turnos en un tablero triangular. Tú juegas con las fichas azules 
+                y el bot adversario juega con las fichas rojas. El juego alterna turnos entre ambos jugadores hasta 
+                que uno de ellos consiga conectar una ruta ganadora.
             </p>
 
-            <h3>Objetivo</h3>
+            <h3>Objetivo del Juego</h3>
             <p>
-                Conectar tus fichas formando una línea continua que conecte los tres lados del tablero antes de que lo haga el bot.
+                Ser el primero en conectar tus fichas formando una línea continua ininterrumpida que toque los tres lados 
+                del tablero triangular antes de que el bot lo consiga.
             </p>
 
-            <h3>Reglas</h3>
+            <h3>El Tablero</h3>
             <p>
-                <ul>
-                    <li>Los jugadores se turnan colocando una ficha por turno.</li>
-                    <li>Sólo puedes colocar fichas en casillas vacías.</li>
-                    <li>El primero en conectar sus dos lados gana la partida.</li>
-                </ul>
+                El tablero es triangular y está dividido en casillas hexagonales. Cada casilla puede contener una ficha 
+                (azul, roja o estar vacía). Los tres lados del triángulo actúan como "bordes del tablero" y son necesarios 
+                para formar tu ruta ganadora. Tus fichas deben estar adyacentes entre sí para formar una línea conectada.
+            </p>
+
+            <h3>Reglas del Juego</h3>
+            <ul>
+                <li><strong>Turnos:</strong> Los jugadores alternan turnos. Tú siempre empiezas primero (fichas azules).</li>
+                <li><strong>Colocación:</strong> En tu turno, haz clic en una casilla vacía del tablero para colocar una de tus fichas.</li>
+                <li><strong>Una ficha por turno:</strong> Solo puedes colocar una ficha por turno.</li>
+                <li><strong>Casillas ocupadas:</strong> No puedes colocar fichas donde ya hay fichas (azules o rojas).</li>
+                <li><strong>Tiempo limitado por turno:</strong> Tienes un tiempo limitado para colocar tu ficha en cada ronda (el temporizador aparece en pantalla). 
+                    Si el tiempo se agota, tu turno se pierde automáticamente y es el turno del bot.</li>
+                <li><strong>Fichas adyacentes:</strong> Tus fichas deben estar conectadas entre sí (compartir bordes con otras fichas tuyas) 
+                    para formar una ruta válida.</li>
+            </ul>
+
+            <h3>Cómo Ganar o Perder</h3>
+            <p>
+                <strong>Ganas</strong> si consigues formar una línea continua de fichas azules que conecte los tres lados del tablero 
+                antes de que el bot lo haga con sus fichas rojas.
+            </p>
+            <p>
+                <strong>Pierdes</strong> si el bot completa su línea ganadora primero.
             </p>
         </div>
     )

--- a/webapp/src/pages/HelpDialog.css
+++ b/webapp/src/pages/HelpDialog.css
@@ -64,13 +64,13 @@
 }
 
 .help-dialog-inner .help-content::-webkit-scrollbar-thumb {
-    background: #4f46e5;
+    background: #06b6d4;
     border-radius: 10px;
     transition: background 0.2s ease;
 }
 
 .help-dialog-inner .help-content::-webkit-scrollbar-thumb:hover {
-    background: #4338ca;
+    background: #0891b2;
 }
 
 .help-dialog-inner .help-content h2 {

--- a/webapp/src/pages/HelpDialog.css
+++ b/webapp/src/pages/HelpDialog.css
@@ -47,9 +47,30 @@
     flex-direction: column;
     gap: 16px;
     box-shadow: 0 4px 24px rgba(79, 70, 229, 0.16);
-    overflow: hidden;
+    overflow-y: auto;
+    overflow-x: hidden;
+    max-height: calc(90vh - 100px);
     max-width: 100%;
     box-sizing: border-box;
+}
+
+.help-dialog-inner .help-content::-webkit-scrollbar {
+    width: 8px;
+}
+
+.help-dialog-inner .help-content::-webkit-scrollbar-track {
+    background: #f3f4f6;
+    border-radius: 10px;
+}
+
+.help-dialog-inner .help-content::-webkit-scrollbar-thumb {
+    background: #4f46e5;
+    border-radius: 10px;
+    transition: background 0.2s ease;
+}
+
+.help-dialog-inner .help-content::-webkit-scrollbar-thumb:hover {
+    background: #4338ca;
 }
 
 .help-dialog-inner .help-content h2 {
@@ -175,6 +196,7 @@
     .help-dialog-inner .help-content {
         padding: 22px 16px;
         border-radius: 18px;
+        max-height: calc(90vh - 80px);
     }
 
     .help-dialog-inner .help-content h2 {


### PR DESCRIPTION
This pull request enhances the help dialog and help content for the game by expanding the rules, clarifying the objectives, and improving the user interface for readability and accessibility. The changes include more detailed gameplay explanations, additional test coverage for new help sections, and improved scrolling behavior in the help dialog.

**Help content and structure improvements:**

* Expanded and clarified the help content in `HelpContent`, including more detailed sections for "Objetivo del Juego", "El Tablero", "Reglas del Juego", and "Cómo Ganar o Perder", with explicit win/lose conditions and clearer explanations of board and turn mechanics.
* Updated tests in `HelpDialog.test.tsx` and `HelpContent.test.tsx` to cover the new help sections and rules, ensuring all new content is rendered and verified. [[1]](diffhunk://#diff-5565b76f69934930fa29cd1f1ab7e80315d84204d7a426ba571390e9a1c75209L29-R112) [[2]](diffhunk://#diff-5565b76f69934930fa29cd1f1ab7e80315d84204d7a426ba571390e9a1c75209L84-R158)

**User interface and accessibility enhancements:**

* Improved the scrolling behavior of the help dialog by enabling vertical scrolling, hiding horizontal overflow, and setting a maximum height for better usability on various screen sizes. [[1]](diffhunk://#diff-75fb55b90aec73371c0c645f34b6861273a6fcae80a17e9add73ae8898093c13L50-R75) [[2]](diffhunk://#diff-75fb55b90aec73371c0c645f34b6861273a6fcae80a17e9add73ae8898093c13R199)
* Added custom scrollbar styles to the help content for a more polished and visually consistent user experience.

Closes #160 